### PR TITLE
Bump workflow actions to latest

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.1.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v3
+        uses: actions/dependency-review-action@v3.1.2

--- a/.github/workflows/enforce-spotless.yml
+++ b/.github/workflows/enforce-spotless.yml
@@ -1,0 +1,51 @@
+# This workflow applies formatted syntax of the code using spotless.
+name: Syntax Check
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch.
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}@${{ github.ref }}+${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+  cancel-in-progress: true
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "spotless"
+  spotless:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
+
+      # Setup Java 17
+      - uses: actions/setup-java@v3.13.0
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      # Setup Gradle
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2.9.0
+
+      # Grant execute permission for gradlew
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # Runs our formatter for easier code review
+      - name: Run spotlessApply
+        run: ./gradlew spotlessApply
+
+      # Check if there are any changes, if so, create a commit and push it
+      - name: Create commit of formatted code
+        uses: stefanzweifel/git-auto-commit-action@v5.0.0
+        with:
+          commit_message: "[Spotless] Apply formatting"

--- a/.github/workflows/gradle-validation.yml
+++ b/.github/workflows/gradle-validation.yml
@@ -10,5 +10,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/checkout@v4.1.1
+      - uses: gradle/wrapper-validation-action@v1.1.0

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,30 +26,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.1.1
       with:
         fetch-depth: 0
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v3.13.0
       with:
         java-version: '17'
         distribution: 'temurin'
     - name: Change Gradle Permissions
       run: chmod +x gradlew
     - name: Setup Gradle to generate and submit dependency graphs
-      uses: gradle/gradle-build-action@v2.6.0
+      uses: gradle/gradle-build-action@v2.9.0
       with:
         dependency-graph: generate-and-submit
     - name: Build with Gradle
-      uses: gradle/gradle-build-action@v2.8.0
+      uses: gradle/gradle-build-action@v2.9.0
       with:
         arguments: build
     - name: Shadow Jar
-      uses: gradle/gradle-build-action@v2.8.0
+      uses: gradle/gradle-build-action@v2.9.0
       with:
         arguments: clean shadowJar
     - name: Upload Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3.1.3
       with:
         name: GalaxeSMP
         path: build/libs/*-all.jar
@@ -62,12 +62,12 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
 
       - name: Download Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3.0.2
         with:
           name: GalaxeSMP
           path: build/libs/
@@ -75,13 +75,12 @@ jobs:
       - name: Deploy to Pterodactyl SFTP
         uses: appleboy/scp-action@master
         with:
-          host: ${{ secrets.SFTP_HOST }}
-          username: ${{ secrets.SFTP_USERNAME }}
-          password: ${{ secrets.SFTP_PASSWORD }}
-          port: ${{ secrets.SFTP_PORT }}
+          host: ${{ secrets.DEV_HOST }}
+          username: ${{ secrets.DEV_USERNAME }}
+          password: ${{ secrets.DEV_PASSWORD }}
+          port: ${{ secrets.DEV_PORT }}
           source: "build/libs/*.jar"
           target: "/plugins/"
           strip_components: 1
           rm: true
-          skip_clean: true
           timeout: 120s


### PR DESCRIPTION
### Information

Some of the GitHub Actions being used were either vulnerable or out of date with sporadic versions used in each different workflow. This aims to resolve that.

### Details

* Bumped `actions/checkout` from `v4` to `v4.1.1`
* Bumped `actions/download-artifact` from `v3` to `v3.0.2`
* Bumped `actions/dependency-review-action` from `v3` to `v3.1.2`
* Bumped `actions/setup-java` from `v3` to `v3.13.0`
* Bumped `actions/upload-artifact` from `v3` to `v3.1.3`
* Bumped `gradle/gradle-build-action` from `v2*` to `v2.9.0`
* Bumped `gradle/wrapper-validation-action` from `v1` to `v1.1.0`

`*` Notes that there were multiple versions of this action across different workflows.